### PR TITLE
#7 change the error from redis to dicedb

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -118,7 +118,8 @@ func (c *DiceDBClient) Executor(in string) {
 		// Execute other commands
 		res, err := c.client.Do(ctx, toArgInterface(args)...).Result()
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
+			formattedErr := strings.ReplaceAll(err.Error(), "redis", "diceDB")
+			fmt.Printf("Error: %v\n", formattedErr)
 			return
 		}
 		c.printReply(res)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f653cfe5-26e0-4547-a12a-1ca2727ada3c)


Changed the error message prefix from "redis" to "diceDB" when trying to fetch a non-existent key.

the PR: #7 