### PR TITLE
fix: add readable dice colors

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -54,6 +54,18 @@ func Run(host string, port int) {
 		dicedbClient.Completer,
 		prompt.OptionPrefix("dicedb> "),
 		prompt.OptionLivePrefix(dicedbClient.LivePrefix),
+		// suggestoin
+		prompt.OptionSuggestionBGColor(prompt.DarkGray),
+		prompt.OptionSuggestionTextColor(prompt.White),
+		// selected suggestion
+		prompt.OptionSelectedSuggestionBGColor(prompt.Red),
+		prompt.OptionSelectedSuggestionTextColor(prompt.Black),
+		// description
+		prompt.OptionDescriptionBGColor(prompt.DarkGray),
+		prompt.OptionDescriptionTextColor(prompt.White),
+		// selected description
+		prompt.OptionSelectedDescriptionBGColor(prompt.Red),
+		prompt.OptionSelectedDescriptionTextColor(prompt.Black),
 	)
 	p.Run()
 	handleExit()


### PR DESCRIPTION
This PR just adds more readable colors 

Tried with default macos terminal:
<img width="688" alt="image" src="https://github.com/user-attachments/assets/8de799ef-9d52-498b-a4e1-5ac93277700c">

and with the tokyonight theme:
<img width="890" alt="image" src="https://github.com/user-attachments/assets/ec7a875a-6d88-4ebd-a727-0ebd8d4c4e14">

As a bonus, it uses dark mode colors (more readable) with "red" to align more with dicedb branding
