### PR TITLE
fix: reset prompt state upon exiting watch mode (issue #15)

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -60,8 +60,8 @@ func Run(host string, port int) {
 			Fn: func(buf *prompt.Buffer) {
 				if dicedbClient.subscribed {
 					fmt.Println("Exiting watch mode.")
-					dicedbClient.subCancel()
-					dicedbClient.wg.Wait()
+
+					dicedbClient.handleWatchModeExit()
 				} else {
 					handleExit()
 				}
@@ -174,6 +174,12 @@ func (c *DiceDBClient) handleWatchCommand(cmd string, args []string) {
 	baseCmd := strings.TrimSuffix(cmd, SuffixWatch)
 
 	go c.watchCommand(baseCmd, toArgInterface(args[1:])...)
+}
+
+func (c *DiceDBClient) handleWatchModeExit() {
+	c.subCancel()
+	c.subscribed = false
+	c.subType = ""
 }
 
 func (c *DiceDBClient) handleUnsubscribe() {

--- a/cli/main.go
+++ b/cli/main.go
@@ -342,8 +342,6 @@ func (c *DiceDBClient) watchCommand(cmd string, args ...interface{}) {
 	for {
 		select {
 		case <-c.subCtx.Done():
-			c.subscribed = false
-			c.subType = ""
 			err = c.watchConn.Unwatch(c.subCtx, cmd, cmdFingerPrint)
 			if err != nil {
 				fmt.Printf("error in unwatch: %v\n", err)

--- a/install.sh
+++ b/install.sh
@@ -56,4 +56,4 @@ echo "\n
 ╚═════╝ ╚═╝ ╚═════╝╚══════╝╚═════╝ ╚═════╝
 "
 echo "> if you get 'command not found' error, add '/usr/local/bin' to your 'PATH' variable."
-echo "\nDiceDB CLI installation complete ✓"
+echo "DiceDB CLI installation complete ✓"


### PR DESCRIPTION
This PR aims to fix issue #15 , where we need to enter one more time after exiting from watch mode to reset dicedb cli.