### PR TITLE
fix: disable completer suggestions while in watch mode

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -218,6 +218,11 @@ func (c *DiceDBClient) handleAuth(args []string, ctx context.Context) {
 }
 
 func (c *DiceDBClient) Completer(d prompt.Document) []prompt.Suggest {
+	suggestions := []prompt.Suggest{}
+
+	if c.subscribed {
+		return suggestions
+	}
 	// Get the text before the cursor
 	beforeCursor := d.TextBeforeCursor()
 	words := strings.Fields(beforeCursor)
@@ -232,7 +237,6 @@ func (c *DiceDBClient) Completer(d prompt.Document) []prompt.Suggest {
 		return nil
 	}
 
-	suggestions := []prompt.Suggest{}
 	for _, cmd := range dicedbCommands {
 		if strings.HasPrefix(strings.ToUpper(cmd), strings.ToUpper(text)) {
 			suggestions = append(suggestions, prompt.Suggest{Text: cmd})


### PR DESCRIPTION
This PR aims to fix issue #14 , Earlier completer suggestions were shown even in watch mode. Now we don't show any suggestions during typing in watch mode.