### PR TITLE
Added parser to allow args with space or quoted chars

### DIFF
--- a/ironhawk/main.go
+++ b/ironhawk/main.go
@@ -62,7 +62,7 @@ func Run(host string, port int) {
 			continue
 		}
 
-		args := strings.Fields(input)
+		args := parseArgs(input)
 		if len(args) == 0 {
 			continue
 		}
@@ -107,4 +107,32 @@ func renderResponse(resp *wire.Response) {
 	case *wire.Response_VNil:
 		fmt.Printf("(nil)\n")
 	}
+}
+
+func parseArgs(input string) []string {
+	var args []string
+	var currentArg string
+	inQuotes := false
+	var quoteChar byte = '"'
+
+	for i := 0; i < len(input); i++ {
+		c := input[i]
+		if c == ' ' && !inQuotes {
+			if currentArg != "" {
+				args = append(args, currentArg)
+				currentArg = ""
+			}
+		} else if (c == '"' || c == '\'') && !inQuotes {
+			inQuotes = true
+			quoteChar = c
+		} else if c == quoteChar && inQuotes {
+			inQuotes = false
+		} else {
+			currentArg += string(c)
+		}
+	}
+	if currentArg != "" {
+		args = append(args, currentArg)
+	}
+	return args
 }


### PR DESCRIPTION
- Key values with quoted/space args where getting truncated, restored the old parser method to fix this.

```
❯ go run main.go                            
localhost:7379> PING "123123 123123"
OK 123123 123123
localhost:7379> SET k1 "hello world"
OK OK
localhost:7379> get k1
OK hello world
localhost:7379> set k1 "\"hello\""
OK OK
localhost:7379> get k1
OK \hello\
```