### PR TITLE
Handle `VList` as response from dice.

### DIFF
--- a/ironhawk/main.go
+++ b/ironhawk/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dicedb/dicedb-go"
 	"github.com/dicedb/dicedb-go/wire"
 	"github.com/fatih/color"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var (
@@ -103,6 +104,17 @@ func renderResponse(resp *wire.Response) {
 			attrs = append(attrs, fmt.Sprintf("%s=%s", k, v))
 		}
 		fmt.Printf("[%s] ", strings.Join(attrs, ", "))
+	}
+
+	if resp.VList != nil {
+		for _, item := range resp.VList {
+			switch v := item.Kind.(type) {
+			case *structpb.Value_StringValue:
+				fmt.Printf("%v\n", item.GetStringValue())
+			default:
+				fmt.Println("Unknown type:", v)
+			}
+		}
 	}
 
 	switch resp.Value.(type) {


### PR DESCRIPTION
Check for `VList` from response to render on cli.
Part of fix: [dice handle `HGETALL` command](https://github.com/DiceDB/dice/pull/1593)

![Screenshot from 2025-03-19 16-25-18](https://github.com/user-attachments/assets/b0183a6b-d25f-4c57-9d59-2491ada6c911)
