### PR TITLE
feat: Add client.CloseWatch() to exit watch mode in Run function

### DIFF
--- a/ironhawk/main.go
+++ b/ironhawk/main.go
@@ -121,6 +121,7 @@ func Run(host string, port int) {
 				case <-sigChanWatchMode:
 					fmt.Println("exiting the watch mode. back to command mode")
 					shouldExitWatchMode = true
+					client.CloseWatch()
 				case resp := <-ch:
 					// If we get any response over the watch channel,
 					// render the response


### PR DESCRIPTION
- Handles multiple watch commands after killing one command, other executes as required